### PR TITLE
updated HMAC in TLS module + fixed bugs in ByteStorage

### DIFF
--- a/src/lib/binary/binary.cc
+++ b/src/lib/binary/binary.cc
@@ -167,14 +167,14 @@ JS_METHOD(Buffer_toString) {
 	if (args.Length() == 0) {
 		size_t tmpSize = 100;
 		std::string result = "[Buffer ";
-		char * tmp = (char *) malloc(tmpSize);
+		char* tmp = new char [tmpSize];//(char *) malloc(tmpSize);
 		if (tmp) {
 			size_t size = snprintf(tmp, tmpSize, "%lu", (unsigned long) bs->getLength());
 			if (size < tmpSize) { result += tmp; }
-			free(tmp);
+			delete[] tmp;
 		}
 		result += "]";
-		JS_STR(result.c_str());
+		args.GetReturnValue().Set(JS_STR(result.c_str()));
 		return;
 	}
 	

--- a/src/lib/binary/bytestorage.cc
+++ b/src/lib/binary/bytestorage.cc
@@ -16,12 +16,12 @@
 #endif
 
 
-ByteStorageData::ByteStorageData(size_t _length,size_t _allocated_length)
+ByteStorageData::ByteStorageData(size_t _length, size_t _allocated_length)
 {
 	if (_length && _allocated_length) {
 		// OK
 	} else if (_length) {
-		_allocated_length=_length;
+		_allocated_length=_length + 1; // dont'forget about '\0' at the end
 	} else {
 		// OK
 	}
@@ -36,6 +36,7 @@ ByteStorageData::ByteStorageData(size_t _length,size_t _allocated_length)
 			//exit(1);
 			ALLOC_ERROR;
 		}
+		this->data[this->allocated_length - 1] = '\0';
 	} else {
 		this->data = NULL;
 	}
@@ -77,18 +78,24 @@ size_t ByteStorageData::getAllocatedLength()
 void ByteStorageData::add(const char *add, size_t _length)
 {
 	//printf("ByteStorageData::add(const char *add,%d) this->length=%d,this->allocated_length=%d\n",_length,this->length,this->allocated_length);
-	if (this->length + _length > this->allocated_length) {
+	if (this->length + _length >= this->allocated_length) {
 		//JS_ISOLATE->AdjustAmountOfExternalAllocatedMemory(-allocated_length);
 		if (!this->allocated_length) {
 			this->allocated_length = 1;
 		}
-		while (this->allocated_length < this->length + _length) {
+		while (this->allocated_length <= this->length + _length) {
 			this->allocated_length *= 2;
 		}
 
 		char *tmp = this->data;
 		//this->allocated_length=(this->length+_length)*1.5;
 		this->data = (char *) malloc(this->allocated_length);
+		if (!this->data) {
+			//fprintf(stderr,"ByteStorageData::ByteStorageData() - Cannot allocate enough memory");
+			//exit(1);
+			ALLOC_ERROR;
+		}
+		this->data[this->allocated_length - 1] = '\0';
 		//JS_ISOLATE->AdjustAmountOfExternalAllocatedMemory(allocated_length);
 		memmove(this->data,tmp,this->length);
 		free(tmp);

--- a/unit/tests/hmac.js
+++ b/unit/tests/hmac.js
@@ -7,7 +7,18 @@ var secret = "secret";
 
 exports.testHMACSHA1 = function() {
     try {
-        assert.equal(TLS.HashHmac(new Buffer("sha1", "utf-8"), new Buffer(plainText, "utf-8"), new Buffer(secret, "utf-8")).toString(),
+        var result = TLS.HashHmac(new Buffer("sha1", "utf-8"), new Buffer(plainText, "utf-8"), new Buffer(secret, "utf-8"));
+        assert.equal(result.toString("utf-8", 0, result.length),
+        "f9bb6c561e49e17a479bd5746411e43efef798e0", "sha1 with 'Testing message.'");
+    } catch(e) {
+        system.stdout.writeLine(e);
+    }
+}
+
+exports.testHMACSHA1_String = function() {
+    try {
+        var result = TLS.HashHmac('sha1', plainText, secret);
+        assert.equal(result.toString("utf-8", 0, result.length),
         "f9bb6c561e49e17a479bd5746411e43efef798e0", "sha1 with 'Testing message.'");
     } catch(e) {
         system.stdout.writeLine(e);


### PR DESCRIPTION
Bugs in ByteStorage:
Missing '\0' at the end of the string;
toString() didn't return actual value in case with zero arguments.
HMAC:
Now arguments can be passed as strings.