### PR TITLE
http.js: always bind SNI to host

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -234,7 +234,6 @@ ClientRequest = function (url) {
 	this.skipPort = false;
 	this.certificateCheck = true;
 	this.TLSMethod = 771;
-	this.SNI = null; // by default SNI would match host from url
 
 	var u = url;
 	var index = u.indexOf("?");
@@ -287,10 +286,6 @@ ClientRequest.prototype.setCertificateCheck = function (check) {
 
 ClientRequest.prototype.setTLSMethod = function (method) {
 	this.TLSMethod = method;
-}
-
-ClientRequest.prototype.setSNI = function (host) {
-	this.SNI = host;
 }
 
 ClientRequest.prototype.header = function (obj, noOverwrite = false) {
@@ -402,12 +397,7 @@ ClientRequest.prototype.send = function (follow) {
 		var TLS = require("tls").TLS;
 		hiddenSocket = socket;
 		socket = new TLS(socket);
-		if (this.SNI == null) {
-			this.SNI = host;
-		}
-		if (this.SNI != "") {
-			socket.setSNI(this.SNI);
-		}
+		socket.setSNI(host);
 		socket.setCertificateCheck(this.certificateCheck);
 		socket.setTLSMethod(this.TLSMethod);
 		socket.connect();
@@ -619,12 +609,7 @@ ClientRequest.prototype.sendFiles = function (follow) {
 		var TLS = require("tls").TLS;
 		hiddenSocket = socket;
 		socket = new TLS(socket);
-		if (this.SNI == null) {
-			this.SNI = host;
-		}
-		if (this.SNI != "") {
-			socket.setSNI(this.SNI);
-		}
+		socket.setSNI(host);
 		socket.connect();
 		if (system.env.PRINT_DEBUGS == 1) {
 			system.stdout.writeLine('CONNECT TLS TIME = ' + (new Date() - dd));
@@ -769,12 +754,7 @@ ClientRequest.prototype.download = function (filepath, follow) {
 		var TLS = require("tls").TLS;
 		hiddenSocket = socket;
 		socket = new TLS(socket);
-		if (this.SNI == null) {
-			this.SNI = host;
-		}
-		if (this.SNI != "") {
-			socket.setSNI(this.SNI);
-		}
+		socket.setSNI(host);
 		socket.connect();
 		if (system.env.PRINT_DEBUGS == 1) {
 			system.stdout.writeLine('CONNECT TLS TIME = ' + (new Date() - dd));


### PR DESCRIPTION
This fixes SNI not being reassigned during redirects