### PR TITLE
http.js: overwrite Host header in ClientRequest.send

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -307,10 +307,10 @@ ClientRequest.prototype.send = function (follow) {
 	var url = items[3];
 	var hiddenSocket = null;
 	if (this.skipPort == true) {
-		this.header({ "Host": host }, true);
+		this.header({ "Host": host });
 	}
 	else {
-		this.header({ "Host": host + ((port == 80 || port == 443) ? "" : ":" + port) }, true);
+		this.header({ "Host": host + ((port == 80 || port == 443) ? "" : ":" + port) });
 	}
 	/* defaults */
 	this.header({


### PR DESCRIPTION
Fixes wrong Host during redirects, etc